### PR TITLE
Add optional x64 build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib/*.obj
 lib/libopenjtalk-timestamp.h
 lib/*.c.orig
 libopenjtalk.dll
+x64/libopenjtalk.dll
 *.pyc
 *.jtlog
 *.wav

--- a/all.mak
+++ b/all.mak
@@ -45,7 +45,12 @@ all:
 	cd lib
 	nmake /f Makefile.mak MACHINE=$(MACHINE)
 	cd ..
-	copy lib\libopenjtalk.dll .
+!IF "$(MACHINE)" == "x64"
+	if not exist x64 mkdir x64
+	copy /Y lib\libopenjtalk.dll x64\libopenjtalk.dll
+!ELSE
+	copy /Y lib\libopenjtalk.dll .
+!ENDIF
 
 clean:
 	nmake /f hts.mak clean

--- a/all.mak
+++ b/all.mak
@@ -43,7 +43,7 @@ all:
 	nmake /f Makefile.mak
 	cd ..
 	cd lib
-	nmake /f Makefile.mak
+	nmake /f Makefile.mak MACHINE=$(MACHINE)
 	cd ..
 	copy lib\libopenjtalk.dll .
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,7 @@
-nmake /f all.mak
+@echo off
+set _M=%1
+if not "%_M%"=="" (
+  nmake /f all.mak MACHINE=%_M%
+) else (
+  nmake /f all.mak
+)

--- a/lib/Makefile.mak
+++ b/lib/Makefile.mak
@@ -13,6 +13,10 @@ OJTDIR = ../libopenjtalk
 HTSDIR = ../htsengineapi
 JPCOMMONDIR = ../jpcommon
 
+!IFNDEF MACHINE
+MACHINE = x86
+!ENDIF
+
 INCLUDES = -I$(OJTDIR)/text2mecab \
            -I$(OJTDIR)/mecab/src \
            -I$(OJTDIR)/mecab2njd \
@@ -58,8 +62,9 @@ libopenjtalk-timestamp.h:
 .c.obj:
 	$(CC) $(INCLUDES) $(CFLAGS) /c $*.c /Fo$@
 
+
 libopenjtalk.dll: libopenjtalk.obj HTS_gstream_ex.obj HTS_engine_ex.obj
-	$(LINK) /DLL /RELEASE /MACHINE:x86 /LTCG /OUT:libopenjtalk.dll \
+	$(LINK) /DLL /RELEASE /MACHINE:$(MACHINE) /LTCG /OUT:libopenjtalk.dll \
 	libopenjtalk.obj HTS_gstream_ex.obj HTS_engine_ex.obj $(LDADD) /DEF:libopenjtalk.def
 
 clean:	

--- a/readme.txt
+++ b/readme.txt
@@ -7,15 +7,19 @@ setup:
 
 Visual Studio 2022
 
-Python 3.11 (win32)
+Python 3.11 (win32 or amd64)
 
 > git clone https://github.com/nvdajp/python-jtalk
 > cd python-jtalk
 > git submodule sync
 > git submodule update --init --recursive
-> vcsetup.cmd
+> vcsetup.cmd           (x86 build)
+or
+> vcsetup.cmd x64       (x64 build)
 > clean.cmd
-> build.cmd
+> build.cmd             (x86 build)
+or
+> build.cmd x64         (x64 build)
 
 > dir ..\nvdajp\source\synthDrivers\jtalk\dic /w
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,10 @@ or
 or
 > build.cmd x64         (x64 build)
 
+Build artifacts:
+- x86 DLL: `libopenjtalk.dll` (repository root)
+- x64 DLL: `x64\libopenjtalk.dll`
+
 > dir ..\nvdajp\source\synthDrivers\jtalk\dic /w
 
 [.]                   [..]                  char.bin

--- a/vcsetup.cmd
+++ b/vcsetup.cmd
@@ -1,30 +1,65 @@
-@rem test nmake and check errorlevel
-cl
-if "%ERRORLEVEL%" neq "9009" goto :done
+@echo off
+@rem Setup MSVC build environment. Usage: vcsetup.cmd [x64|x86]
+@rem Default is x86 for backward compatibility.
 
-if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2022x64
-if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2019x64
-if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2017x64
-if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat" goto vc2015x64
+@rem If cl is already available, nothing to do.
+cl >NUL 2>&1
+if "%ERRORLEVEL%" NEQ "9009" goto :done
 
-:vc2022x64
+setlocal
+set ARCH=%1
+if /I "%ARCH%"=="x64" goto :detect_x64
+
+@rem ----- x86 toolchain -----
+if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2022x86
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2019x86
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat" goto vc2017x86
+if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat" goto vc2015x86
+goto :done
+
+:vc2022x86
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
 SET CL=/arch:IA32
-goto done
+goto :done
 
-:vc2019x64
+:vc2019x86
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
 SET CL=/arch:IA32
-goto done
+goto :done
 
-:vc2017x64
+:vc2017x86
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 SET CL=/arch:IA32
-goto done
+goto :done
 
-:vc2015x64
+:vc2015x86
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
 SET CL=/arch:IA32 /D "_USING_V110_SDK71_"
-goto done
+goto :done
+
+:detect_x64
+@rem ----- x64 toolchain -----
+if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" goto vc2022x64
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat" goto vc2019x64
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" goto vc2017x64
+if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" goto vc2015x64
+goto :done
+
+:vc2022x64
+call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+goto :done
+
+:vc2019x64
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+goto :done
+
+:vc2017x64
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+goto :done
+
+:vc2015x64
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+goto :done
 
 :done
+endlocal


### PR DESCRIPTION
This PR adds optional x64 build support on Windows.

- vcsetup.cmd accepts x64 to initialize 64-bit MSVC environment.
- lib/Makefile.mak uses /MACHINE: (default x86); pass MACHINE=x64 to build 64-bit DLL.
- all.mak forwards MACHINE to lib build.
- build.cmd accepts optional x64 argument to set MACHINE.
- readme.txt updated with x64 instructions.

Build examples:

- x86:  vcsetup.cmd, then build.cmd
- x64:  vcsetup.cmd x64, then build.cmd x64

Note: Ensure 64-bit Python is used with the 64-bit DLLs.